### PR TITLE
Add invalidateSize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,5 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+.DS_Store

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
@@ -33,8 +33,9 @@ namespace FisSst.BlazorMaps
         private const string setZoom = "setZoom";
         private const string zoomIn = "zoomIn";
         private const string zoomOut = "zoomOut";
-        private const string setZoomAround = "setZoomAround";        
-
+        private const string setZoomAround = "setZoomAround";
+        private const string invalidateSize = "invalidateSize";
+        
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
@@ -87,6 +88,11 @@ namespace FisSst.BlazorMaps
         public async Task SetZoomAround(LatLng latLng, int zoom)
         {
             await this.MapReference.InvokeAsync<IJSObjectReference>(setZoomAround, latLng, zoom);
+        }
+
+        public async Task InvalidateSize()
+        {
+            await this.MapReference.InvokeAsync<IJSObjectReference>(invalidateSize);
         }
 
         public async Task OnClick(Func<MouseEvent, Task> callback)


### PR DESCRIPTION
I use Leaflet maps in a resizable container in my Blazor app. I needed the ability to call invalidateSize() when the container changes size so that leaflet will use the proper dimensions when knowing when to ask for more tiles.

Not sure if you are taking pull requests or not, but thought I would pass it on.