### PR TITLE
Add getBounds, fitBounds, Rectangle

### DIFF
--- a/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor
@@ -29,6 +29,9 @@
     <SidePanelButton Label="set zoom around"
                      IconSrc="@Icons.InitializationSetZoomAroundIconSrc"
                      OnClick="async () => await mapRef.SetZoomAround(center, 10)" />
+    <SidePanelButton Label="get, fitBounds, Rectangle sample"
+                   IconSrc="@Icons.InitializationSetZoomAroundIconSrc"
+                   OnClick="async () => await SetMapInitialView(center)" />
 </div>
 
 <style>

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
@@ -42,7 +42,7 @@ namespace FisSst.BlazorMaps.Examples.Pages
         }
         
         // Sample to demonstrate getBounds, fitBounds and Rectangle
-        // At end a There will be a zoomed square with 500m radius
+        // Create a zoomed square with 500m radius
         private async Task SetMapInitialView(LatLng pOrigem)
         {
             CircleOptions zDummyOptions = new CircleOptions { Radius = 500, Color = "red" };                 // Set Circle Options
@@ -50,7 +50,7 @@ namespace FisSst.BlazorMaps.Examples.Pages
             LatLngBounds zBounds = await zDummy.GetBounds();                                                 // Get Circle bounds (SW/NE coords)
             await zDummy.Remove();                                                                           // Remove Circle from map
             RectangleOptions zROptions = new RectangleOptions { Color = "blue" };                            // Set Rectangle Options
-            Rectangle retangulo = await this.RectangleFactory.CreateAndAddToMap(zBounds.ToLatLng(), mapRef, zROptions); // Place Rectangle on map using Bounds from Circle
+            Rectangle rectangle = await this.RectangleFactory.CreateAndAddToMap(zBounds.ToLatLng(), mapRef, zROptions); // Place Rectangle on map using Bounds from Circle
             await this.mapRef.FitBounds(zBounds.ToLatLng());                                                 // FitBounds, some king of Zoom All
         }
     }

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
@@ -32,10 +32,26 @@ namespace FisSst.BlazorMaps.Examples.Pages
         [Inject]
         private IJSRuntime JsRuntime { get; init; }
 
+        [Inject]
+        private IRectangleFactory RectangleFactory { get; init; }
+        
         private async Task GetCenterExample()
         {
             LatLng center = await this.mapRef.GetCenter();
             await this.JsRuntime.InvokeAsync<string>("alert", $"Map centered at: Lat: {center.Lat}, Lng: {center.Lng}");
+        }
+        
+        // Sample to demonstrate getBounds, fitBounds and Rectangle
+        // At end a There will be a zoomed square with 500m radius
+        private async Task SetMapInitialView(LatLng pOrigem)
+        {
+            CircleOptions zDummyOptions = new CircleOptions { Radius = 500, Color = "red" };                 // Set Circle Options
+            Circle zDummy = await this.CircleFactory.CreateAndAddToMap(pOrigem, this.mapRef, zDummyOptions); // Place circle on map
+            LatLngBounds zBounds = await zDummy.GetBounds();                                                 // Get Circle bounds (SW/NE coords)
+            await zDummy.Remove();                                                                           // Remove Circle from map
+            RectangleOptions zROptions = new RectangleOptions { Color = "blue" };                            // Set Rectangle Options
+            Rectangle retangulo = await this.RectangleFactory.CreateAndAddToMap(zBounds.ToLatLng(), mapRef, zROptions); // Place Rectangle on map using Bounds from Circle
+            await this.mapRef.FitBounds(zBounds.ToLatLng());                                                 // FitBounds, some king of Zoom All
         }
     }
 }

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps.Examples/Pages/Index.razor.cs
@@ -33,6 +33,9 @@ namespace FisSst.BlazorMaps.Examples.Pages
         private IJSRuntime JsRuntime { get; init; }
 
         [Inject]
+        private ICircleFactory CircleFactory { get; init; }
+        
+        [Inject]
         private IRectangleFactory RectangleFactory { get; init; }
         
         private async Task GetCenterExample()

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace FisSst.BlazorMaps
 {

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Components/Map.razor.cs
@@ -37,7 +37,8 @@ namespace FisSst.BlazorMaps
         private const string zoomIn = "zoomIn";
         private const string zoomOut = "zoomOut";
         private const string setZoomAround = "setZoomAround";        
-
+        private const string fitBounds = "fitBounds";
+        
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
@@ -130,6 +131,19 @@ namespace FisSst.BlazorMaps
         public async Task Off(string eventType)
         {
             await this.MapEvented.Off(eventType);
+        }
+        
+        /// <summary>
+        /// As far Leaflet (javascript) can accept getBounds() as parameter for fitBounds()
+        /// Here we have to make some transform to give proper values for fitBounds() and prevent Exception "Bounds are not valid."
+        /// Due to _southwest & _northeast returned by getBounds()
+        /// All Leaflet methods that accept LatLngBounds objects also accept them in a simple Array form (unless noted otherwise), so the bounds can be passed like this:
+        /// map.fitBounds([ [40.712, -74.227], [40.774, -74.125] ])
+        /// </summary>
+        /// <param name="coords">Use ToLatLng extension method from LatLngBounds</param>
+        public async Task FitBounds(IEnumerable<LatLng> coords)
+        {
+          await this.MapReference.InvokeAsync<IJSObjectReference>(fitBounds, coords);
         }
     }
 }

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Configurations/DependencyInjection/FisSstMapsDependencyInjection.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Configurations/DependencyInjection/FisSstMapsDependencyInjection.cs
@@ -26,6 +26,7 @@ namespace FisSst.BlazorMaps.DependencyInjection
             services.AddTransient<IPolygonFactory, PolygonFactory>();
             services.AddTransient<ICircleMarkerFactory, CircleMarkerFactory>();
             services.AddTransient<ICircleFactory, CircleFactory>();
+            services.AddTransient<IRectangleFactory, RectangleFactory>();
         }
 
         private static void AddJsInterops(IServiceCollection services)

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Factories/Rectangle/IRectangleFactory.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Factories/Rectangle/IRectangleFactory.cs
@@ -1,0 +1,15 @@
+﻿// Added: New Interface to use Leaflet L.rectangle
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FisSst.BlazorMaps
+{
+  public interface IRectangleFactory
+  {
+    Task<Rectangle> Create(IEnumerable<LatLng> latLngs);
+    Task<Rectangle> Create(IEnumerable<LatLng> latLngs, PolylineOptions options);
+    Task<Rectangle> CreateAndAddToMap(IEnumerable<LatLng> latLngs, Map map);
+    Task<Rectangle> CreateAndAddToMap(IEnumerable<LatLng> latLngs, Map map, PolylineOptions options);
+  }
+}

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Factories/Rectangle/RectangleFactory.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Factories/Rectangle/RectangleFactory.cs
@@ -1,0 +1,50 @@
+﻿// Added: New Class to use Leaflet L.rectangle
+
+using FisSst.BlazorMaps.JsInterops.Events;
+using Microsoft.JSInterop;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FisSst.BlazorMaps
+{
+  internal class RectangleFactory : IRectangleFactory
+  {
+    private const string create = "L.rectangle";
+    private readonly IJSRuntime jsRuntime;
+    private readonly IEventedJsInterop eventedJsInterop;
+
+    public RectangleFactory(
+            IJSRuntime jsRuntime,
+            IEventedJsInterop eventedJsInterop)
+    {
+      this.jsRuntime = jsRuntime;
+      this.eventedJsInterop = eventedJsInterop;
+    }
+
+    public async Task<Rectangle> Create(IEnumerable<LatLng> latLngs)
+    {
+      IJSObjectReference jsReference = await this.jsRuntime.InvokeAsync<IJSObjectReference>(create, latLngs);
+      return new Rectangle(jsReference, this.eventedJsInterop);
+    }
+
+    public async Task<Rectangle> Create(IEnumerable<LatLng> latLngs, PolylineOptions options)
+    {
+      IJSObjectReference jsReference = await this.jsRuntime.InvokeAsync<IJSObjectReference>(create, latLngs, options);
+      return new Rectangle(jsReference, this.eventedJsInterop);
+    }
+
+    public async Task<Rectangle> CreateAndAddToMap(IEnumerable<LatLng> latLngs, Map map)
+    {
+      Rectangle rectangle = await this.Create(latLngs);
+      await rectangle.AddTo(map);
+      return rectangle;
+    }
+
+    public async Task<Rectangle> CreateAndAddToMap(IEnumerable<LatLng> latLngs, Map map, PolylineOptions options)
+    {
+      Rectangle rectangle = await this.Create(latLngs, options);
+      await rectangle.AddTo(map);
+      return rectangle;
+    }
+  }
+}

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Basics/LatLngBounds.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Basics/LatLngBounds.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace FisSst.BlazorMaps
+{
+  public class LatLngBounds
+  {
+    public LatLngBounds()
+    {
+    }
+
+    public LatLngBounds(LatLng southwest, LatLng northeast)
+    {
+      _southWest = southwest;
+      _northEast = northeast;
+    }
+
+    public LatLng _southWest { get; set; }
+    public LatLng _northEast { get; set; }
+
+    public IEnumerable<LatLng> ToLatLng()
+    {
+      return new List<LatLng>() { _southWest, _northEast };
+    }
+  }
+}

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Paths/Path.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Paths/Path.cs
@@ -13,7 +13,8 @@ namespace FisSst.BlazorMaps
         private const string SetStyleJsFunction = "setStyle";
         private const string BringToFrontJsFunction = "bringToFront";
         private const string BringToBackJsFunction = "bringToBack";
-
+        private const string GetBoundsJsFunction = "getBounds";
+        
         public async Task<Path> Redraw()
         {
             await this.JsReference.InvokeAsync<IJSObjectReference>(RedrawJsFunction);
@@ -36,6 +37,17 @@ namespace FisSst.BlazorMaps
         {
             await this.JsReference.InvokeAsync<IJSObjectReference>(BringToBackJsFunction);
             return this;
+        }
+        
+        /// <summary>
+        /// Leaflet getBounds() function returns  
+        /// {"_southWest":{"lat":-23.601783040147975,"lng":-46.537071217637845}, "_northEast":{"lat":-23.556816959852032,"lng":-46.48800878236214}}"
+        /// </summary>
+        /// <returns>LatLngBounds</returns>
+        public async Task<LatLngBounds> GetBounds()
+        {
+          
+          return await this.JsReference.InvokeAsync<LatLngBounds>(GetBoundsJsFunction);
         }
     }
 }

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Rectangle/Rectangle.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Rectangle/Rectangle.cs
@@ -1,0 +1,19 @@
+﻿// Added: Model Class for Rectangle
+
+using FisSst.BlazorMaps.JsInterops.Events;
+using Microsoft.JSInterop;
+using System.Threading.Tasks;
+
+namespace FisSst.BlazorMaps
+{
+  /// <summary>
+  /// A rectangle
+  /// </summary>
+  public class Rectangle : Polyline
+  {
+    internal Rectangle(IJSObjectReference jsReference, IEventedJsInterop eventedJsInterop)
+        : base(jsReference, eventedJsInterop)
+    {
+    }
+  }
+}

--- a/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Rectangle/RectangleOptions.cs
+++ b/FisSst.BlazorMaps/FisSst.BlazorMaps/Models/Rectangle/RectangleOptions.cs
@@ -1,0 +1,15 @@
+﻿// Added: Model Class for Rectangle Options
+
+namespace FisSst.BlazorMaps
+{
+  /// <summary>
+  /// Determines Polygon's properties. 
+  /// </summary>
+  public class RectangleOptions : PolylineOptions
+  {
+    public RectangleOptions()
+    {
+      Fill = true;
+    }
+  }
+}


### PR DESCRIPTION
getBounds, fitbounds and Rectangle are existing features in Leaflet,
getBounds is used to get a rectangular area used by Circle, Rectangle, Polygon, Polylines, etc.
fitBounds is used to Zoom an specific area, usually enclosed by getBounds result.
Rectangle, can be created just with SW/NE coords, no need a Polyline with 4 corners.

For getBounds result a new class should be created to collect results in SW/NE format, also same class have a extension method for fitBounds 